### PR TITLE
Fix Base64URL decoding padding

### DIFF
--- a/Sources/VaporJWT/Encodings/Base64URLEncoding.swift
+++ b/Sources/VaporJWT/Encodings/Base64URLEncoding.swift
@@ -52,7 +52,8 @@ struct Base64URLTranscoder: Base64URLTranscoding {
 
         let characterCount = unpadded.utf8CString.count - 1 // ignore last /0
 
-        let paddingCount = 4 - (characterCount % 4)
+        let paddingRemainder = (characterCount % 4)
+        let paddingCount = paddingRemainder > 0 ? 4 - paddingRemainder : 0
         let padding = Array(repeating: "=", count: paddingCount).joined()
 
         return unpadded + padding

--- a/Tests/VaporJWTTests/Base64TranscoderTestsTests.swift
+++ b/Tests/VaporJWTTests/Base64TranscoderTestsTests.swift
@@ -10,8 +10,13 @@ final class Base64TranscoderTests: XCTestCase {
         XCTAssertEqual(Base64URLTranscoder().base64Encode("abc-_"), "abc+/===")
     }
 
+    func testZeroPadding() {
+        XCTAssertEqual(Base64URLTranscoder().base64Encode("abcd"), "abcd")
+    }
+
     static let all = [
         ("testBase64ToBase64URL", testBase64ToBase64URL),
         ("testBase64URLToBase64", testBase64URLToBase64),
+        ("testZeroPadding", testZeroPadding)
     ]
 }


### PR DESCRIPTION
This fixes #8 
- [BUG FIX] : calling `Base64URLTranscoder().base64Encode("abcd")` will now return `"abcd"` (which is the expected result) and no longer `"abcd===="` (which caused errors).
