### PR TITLE
Fix release-mode linking errors

### DIFF
--- a/Sources/VaporJWT/ClaimsVerifiable.swift
+++ b/Sources/VaporJWT/ClaimsVerifiable.swift
@@ -1,6 +1,6 @@
 import JSON
 
-protocol ClaimsVerifiable {
+public protocol ClaimsVerifiable {
     var node: Node { get }
 }
 

--- a/Sources/VaporJWT/JWT.swift
+++ b/Sources/VaporJWT/JWT.swift
@@ -95,7 +95,7 @@ public struct JWT {
 }
 
 extension JWT: ClaimsVerifiable {
-    var node: Node {
+    public var node: Node {
         return payload
     }
 }

--- a/Sources/VaporJWT/JWTError.swift
+++ b/Sources/VaporJWT/JWTError.swift
@@ -1,4 +1,4 @@
-enum JWTError: Error {
+public enum JWTError: Error {
     case createKey
     case createPublicKey
     case decoding


### PR DESCRIPTION
This PR solves `undefined reference to ...` linking errors by making the `ClaimsVerifiable` protocol public.

Should fix #11